### PR TITLE
Ensure the installation path exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ function getInstallationPath(callback) {
             dir = stdout.trim();
         }
 
+        mkdirp.sync(dir);
 
         callback(null, dir);
     });


### PR DESCRIPTION
When a `go-npm`-enabled module is installed, `go-npm` will pick a destination directory for said module's binary based on the output of `npm bin`. However, if there's no `node_modules` sub-directory present (which is the case when `npm` hoists the dependencies of such module up), the installation directory suggested by `npm bin` doesn't exist and the installation fails.

This fix ensures that the installation directory exists.