### PR TITLE
Add support for Yarn

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ const ARCH_MAPPING = {
     "arm": "arm"
 };
 
-// Mapping between Node's `process.platform` to Golang's 
+// Mapping between Node's `process.platform` to Golang's
 const PLATFORM_MAPPING = {
     "darwin": "darwin",
     "linux": "linux",
@@ -27,9 +27,10 @@ const PLATFORM_MAPPING = {
 
 function getInstallationPath(callback) {
 
-    // `npm bin` will output the path where binary files should be installed
-    exec("npm bin", function(err, stdout, stderr) {
-
+    // `$npm_execpath bin` will output the path where binary files should be installed
+    // using whichever package manager is current
+    const packageManager = process.env.npm_execpath || 'npm';
+    exec(`${packageManager} bin`, function(err, stdout, stderr) {
         let dir =  null;
         if (err || stderr || !stdout || stdout.length === 0)  {
 


### PR DESCRIPTION
I haven't performed the most rigorous testing (I'm not sure of how to)

I've tried installing this package with `npm` and `yarn` as well as `aws-sam-local` with an overridden `go-npm` dependency. Both seem to work.

It also works when you are running `go-npm` directly.

Should fix #1 and should also fix awslabs/aws-sam-local#87